### PR TITLE
Add SEO component

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cy-open": "CYPRESS_BASE_URL=http://localhost:8000 cypress open",
     "e2e": "start-server-and-test start http://localhost:8000 cy-open",
     "cy-static": "CYPRESS_BASE_URL=http://localhost:9000 cypress open",
-    "cy-run": "cypress run",
+    "cy-run": "cypress run --browser chrome --headless",
     "e2e-ci": "start-server-and-test serve http://localhost:9000 cy-run",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
     "prettier": "prettier --ignore-path .gitignore '**/*.+(js)'",

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import Header from '../Header'
 import Footer from '../Footer'
-import {Helmet, HelmetProvider} from 'react-helmet-async'
 import {string, node} from 'prop-types'
 import Box from '@material-ui/core/Box'
 import theme from '../../utils/theme'
 import {makeStyles, ThemeProvider} from '@material-ui/core/styles'
+import SEO from '../SEO'
 
 const useStyles = makeStyles(theme => ({
   body: {
@@ -16,11 +16,8 @@ const useStyles = makeStyles(theme => ({
 const Layout = ({title, children}) => {
   const classes = useStyles()
   return (
-    <HelmetProvider>
-      <Helmet>
-        <html lang="en" />
-        <title>{title}</title>
-      </Helmet>
+    <>
+      <SEO title={title} />
       <ThemeProvider theme={theme}>
         <Box component="main" className={classes.body}>
           <Header />
@@ -30,7 +27,7 @@ const Layout = ({title, children}) => {
           <Footer />
         </Box>
       </ThemeProvider>
-    </HelmetProvider>
+    </>
   )
 }
 

--- a/src/components/Layout/test/Layout.test.js
+++ b/src/components/Layout/test/Layout.test.js
@@ -5,6 +5,7 @@ import render from '../../../utils/tests/renderWithTheme'
 import Layout from '../'
 import mockHeader from '../../../stubs/mockHeader'
 import mockFooter from '../../../stubs/mockFooter'
+import mockSEO from '../../../stubs/mockSEO'
 
 const title = 'page title'
 
@@ -13,6 +14,7 @@ beforeEach(() => {
 })
 
 it('should add a title to the browser page and correct html attributes', async () => {
+  mockSEO()
   mockHeader()
   mockFooter()
   const text = 'child component'

--- a/src/components/SEO/SEO.js
+++ b/src/components/SEO/SEO.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import {string} from 'prop-types'
+
+import {Helmet, HelmetProvider} from 'react-helmet-async'
+
+const SEO = ({title}) => (
+  <HelmetProvider>
+    <Helmet>
+      <html lang="en" />
+      <title>{title}</title>
+      <meta
+        name="description"
+        content="The Palace of Westminster is one of the most iconic and significant buildings in the world, and home to one of the busiest parliaments, with more than a million visitors."
+      />
+      <meta
+        name="keywords"
+        content="Restoration and Renewal, Parliament, R&R, Parliament Restoration"
+      />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </Helmet>
+  </HelmetProvider>
+)
+
+SEO.propTypes = {
+  title: string.isRequired,
+}
+
+export default SEO

--- a/src/components/SEO/SEO.js
+++ b/src/components/SEO/SEO.js
@@ -2,27 +2,43 @@ import React from 'react'
 import {string} from 'prop-types'
 
 import {Helmet, HelmetProvider} from 'react-helmet-async'
+import {useStaticQuery, graphql} from 'gatsby'
 
-const SEO = ({title}) => (
-  <HelmetProvider>
-    <Helmet>
-      <html lang="en" />
-      <title>{title}</title>
-      <meta
-        name="description"
-        content="The Palace of Westminster is one of the most iconic and significant buildings in the world, and home to one of the busiest parliaments, with more than a million visitors."
-      />
-      <meta
-        name="keywords"
-        content="Restoration and Renewal, Parliament, R&R, Parliament Restoration"
-      />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-    </Helmet>
-  </HelmetProvider>
-)
+const SEO = ({title, description}) => {
+  const data = useStaticQuery(graphql`
+    query MetaData {
+      contentfulSiteMetaData {
+        title
+        tags
+        description
+      }
+    }
+  `)
+
+  const {
+    contentfulSiteMetaData: {
+      title: seoTitle,
+      description: seoDescription,
+      tags,
+    },
+  } = data
+
+  return (
+    <HelmetProvider>
+      <Helmet>
+        <html lang="en" />
+        <title>{title || seoTitle}</title>
+        <meta name="description" content={description || seoDescription} />
+        <meta name="keywords" content={tags.join(', ')} />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Helmet>
+    </HelmetProvider>
+  )
+}
 
 SEO.propTypes = {
-  title: string.isRequired,
+  title: string,
+  description: string,
 }
 
 export default SEO

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -1,0 +1,1 @@
+export {default} from './SEO'

--- a/src/components/SEO/stories/SEO.stories.js
+++ b/src/components/SEO/stories/SEO.stories.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import SEO from '../SEO'
+
+export default {title: 'SEO'}
+
+export const withProps = () => <SEO />

--- a/src/components/SEO/test/SEO.test.js
+++ b/src/components/SEO/test/SEO.test.js
@@ -1,17 +1,36 @@
 import React from 'react'
 import {waitForDomChange} from '@testing-library/react'
 import render from '../../../utils/tests/renderWithTheme'
+import seoData from '../../../stubs/seoData'
+import mockSEO from '../../../stubs/mockSEO'
 
 import SEO from '../'
 
 const title = 'page title'
+const description = 'page description'
 
 beforeEach(() => {
   jest.clearAllMocks()
 })
 
-it('should add a title to the browser page and correct html attributes', async () => {
-  render(<SEO title={title} />)
+it('should add a title to the browser page and correct meta tags', async () => {
+  mockSEO()
+  render(<SEO title={title} description={description} />)
   await waitForDomChange()
+  const metaDescription = document.querySelector('meta[name="description"]')
+    .content
+  const metaTags = document.querySelector('meta[name="keywords"]').content
   expect(document.title).toEqual(title)
+  expect(metaDescription).toEqual(description)
+  expect(metaTags).toEqual(seoData.contentfulSiteMetaData.tags.join(', '))
+})
+
+it('should display the default meta data', async () => {
+  mockSEO()
+  render(<SEO />)
+  await waitForDomChange()
+  expect(document.title).toEqual(seoData.contentfulSiteMetaData.title)
+  const metaDescription = document.querySelector('meta[name="description"]')
+    .content
+  expect(metaDescription).toEqual(seoData.contentfulSiteMetaData.description)
 })

--- a/src/components/SEO/test/SEO.test.js
+++ b/src/components/SEO/test/SEO.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import {waitForDomChange} from '@testing-library/react'
+import render from '../../../utils/tests/renderWithTheme'
+
+import SEO from '../'
+
+const title = 'page title'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('should add a title to the browser page and correct html attributes', async () => {
+  render(<SEO title={title} />)
+  await waitForDomChange()
+  expect(document.title).toEqual(title)
+})

--- a/src/pages/test/index.test.js
+++ b/src/pages/test/index.test.js
@@ -3,9 +3,9 @@ import IndexPage from '../'
 import {waitForDomChange} from '@testing-library/react'
 import render from '../../utils/tests/renderWithTheme'
 import '@testing-library/jest-dom/extend-expect'
-import mockData from '../../stubs/mockData'
-import headerData from '../../stubs/headerData'
 import mockFooter from '../../stubs/mockFooter'
+import mockSEO from '../../stubs/mockSEO'
+import mockHeader from '../../stubs/mockHeader'
 
 const heroImageTitle = 'Hero image title'
 
@@ -55,7 +55,8 @@ const homePageData = {
 }
 
 test('should show page title, main heading text and section links', async () => {
-  mockData(headerData)
+  mockSEO()
+  mockHeader()
   mockFooter()
   const title = 'Restoration and Renewal'
   const {getByText, getByTestId, getByAltText} = render(

--- a/src/stubs/mockSEO.js
+++ b/src/stubs/mockSEO.js
@@ -1,0 +1,4 @@
+import seoData from './seoData'
+import mockData from './mockData'
+
+export default () => mockData(seoData)

--- a/src/stubs/seoData.js
+++ b/src/stubs/seoData.js
@@ -1,0 +1,13 @@
+export default {
+  contentfulSiteMetaData: {
+    title: 'Restoration & Renewal',
+    tags: [
+      'Restoration & Renewal Programme',
+      'Houses Of Parliament R&R',
+      'R&R',
+      'Westminster',
+    ],
+    description:
+      'The Palace of Westminster Restoration & Renewal Programme has been established to tackle the work that needs to be done to preserve the heritage of the Palace of Westminster and ensure it continues to serve as home to the UK Parliament in the 21st century.',
+  },
+}

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -3,9 +3,9 @@ import Article from '..'
 import {waitForDomChange} from '@testing-library/react'
 import render from '../../../utils/tests/renderWithTheme'
 import '@testing-library/jest-dom/extend-expect'
-import mockData from '../../../stubs/mockData'
-import headerData from '../../../stubs/headerData'
 import mockFooter from '../../../stubs/mockFooter'
+import mockSEO from '../../../stubs/mockSEO'
+import mockHeader from '../../../stubs/mockHeader'
 
 const data = {
   contentfulArticle: {
@@ -14,7 +14,8 @@ const data = {
 }
 
 test('should render title and component', async () => {
-  mockData(headerData)
+  mockSEO()
+  mockHeader()
   mockFooter()
   const {getByText} = render(<Article data={data} />)
   await waitForDomChange()

--- a/src/templates/Page/test/Page.test.js
+++ b/src/templates/Page/test/Page.test.js
@@ -4,6 +4,7 @@ import {waitForDomChange} from '@testing-library/react'
 import render from '../../../utils/tests/renderWithTheme'
 import mockFooter from '../../../stubs/mockFooter'
 import mockHeader from '../../../stubs/mockHeader'
+import mockSEO from '../../../stubs/mockSEO'
 
 import Page from '..'
 
@@ -14,6 +15,7 @@ const data = {
 }
 
 it('should render the component', async () => {
+  mockSEO()
   mockHeader()
   mockFooter()
   const {getByText} = render(<Page data={data} />)

--- a/src/templates/Section/test/Section.test.js
+++ b/src/templates/Section/test/Section.test.js
@@ -5,6 +5,7 @@ import render from '../../../utils/tests/renderWithTheme'
 import '@testing-library/jest-dom/extend-expect'
 import mockHeader from '../../../stubs/mockHeader'
 import mockFooter from '../../../stubs/mockFooter'
+import mockSEO from '../../../stubs/mockSEO'
 
 const heroImageTitle = 'Hero image title'
 
@@ -41,6 +42,7 @@ beforeEach(() => {
 })
 
 test('show page title and component', async () => {
+  mockSEO()
   mockHeader()
   mockFooter()
   const {getByText} = render(<Section data={data} />)
@@ -50,6 +52,7 @@ test('show page title and component', async () => {
 })
 
 test('should show all the articles', () => {
+  mockSEO()
   mockHeader()
   mockFooter()
   const {getByText} = render(<Section data={data} />)


### PR DESCRIPTION
## Description
Improve SEO scoring by adding right metatags

## Changelog
- Add SEO component
- Add meta tags within it
- Fix Cypress Ci failure by using Chrome headless instead of Electron

## Checks

- [x] 80% test coverage


## Tested in 
- [x] Chrome
- [x] Safari
