### PR TITLE
Feature/article card grid

### DIFF
--- a/src/components/ArticleCard/ArticleCard.js
+++ b/src/components/ArticleCard/ArticleCard.js
@@ -3,28 +3,20 @@ import {string, object, shape} from 'prop-types'
 import {Link} from 'gatsby'
 import Typography from '@material-ui/core/Typography'
 import RichText from '../RichText/RichText'
-import Card from '@material-ui/core/Card'
-import CardContent from '@material-ui/core/CardContent'
+import Paper from '@material-ui/core/Paper'
 import Box from '@material-ui/core/Box'
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward'
 import {makeStyles} from '@material-ui/core/styles'
 
 const useStyles = makeStyles(theme => ({
-  sectionPreview: {
+  articlePreview: {
     color: theme.palette.primary.main,
     lineHeight: '28px',
-    fontSize: '21px',
   },
   cardContent: {
     padding: '28px',
   },
-  previewImage: {
-    width: '430px',
-    height: '220px',
-    margin: '28px auto 0',
-  },
   card: {
-    width: '324px',
     height: '427px',
     position: 'relative',
     borderLeft: '7px solid purple',
@@ -33,7 +25,6 @@ const useStyles = makeStyles(theme => ({
 
     [theme.breakpoints.up('md')]: {
       height: '301px',
-      width: '480px',
     },
   },
   arrowIcon: {
@@ -49,6 +40,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     bottom: 0,
     marginBottom: '28px',
+    marginRight: '10px',
   },
   previewWrapper: {
     maxHeight: '110px',
@@ -59,27 +51,29 @@ const useStyles = makeStyles(theme => ({
 const ArticleCard = ({title, previewText, linkText, slug, sectionSlug}) => {
   const classes = useStyles()
   return (
-    <Card className={classes.card}>
-      <CardContent className={classes.cardContent}>
-        <Box mb={1}>
-          <Typography variant="h2">{title}</Typography>
+    <Box>
+      <Paper className={classes.card}>
+        <Box className={classes.cardContent}>
+          <Box mb={1}>
+            <Typography variant="h2">{title}</Typography>
+          </Box>
+          <Box mb={1} className={classes.previewWrapper}>
+            <RichText
+              className={classes.articlePreview}
+              text={previewText}
+              aria-label="article description"
+            />
+          </Box>
+          <Box className={classes.linkWrapper}>
+            <Link to={`/${sectionSlug}/${slug}`} className={classes.link}>
+              <Typography variant="body2">
+                {linkText} <ArrowForwardIcon className={classes.arrowIcon} />
+              </Typography>
+            </Link>
+          </Box>
         </Box>
-        <Box mb={1} className={classes.previewWrapper}>
-          <RichText
-            className={classes.sectionPreview}
-            text={previewText}
-            aria-label="section description"
-          />
-        </Box>
-        <Box className={classes.linkWrapper}>
-          <Link to={`/${sectionSlug}/${slug}`} className={classes.link}>
-            <Typography variant="body2">
-              {linkText} <ArrowForwardIcon className={classes.arrowIcon} />
-            </Typography>
-          </Link>
-        </Box>
-      </CardContent>
-    </Card>
+      </Paper>
+    </Box>
   )
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,14 +38,7 @@ const Index = ({
               hero: {image},
               childContentfulSectionPreviewContentRichTextNode,
             }) => (
-              <Grid
-                item
-                key={`${title}-${slug}`}
-                xs="auto"
-                sm={6}
-                md={6}
-                lg={4}
-              >
+              <Grid item key={`${title}-${slug}`} xs={12} sm={6} md={6} lg={4}>
                 <SectionCard
                   image={image}
                   sectionTitle={sectionTitle}

--- a/src/templates/Section/Section.js
+++ b/src/templates/Section/Section.js
@@ -34,14 +34,7 @@ const Section = ({
               previewLinkText,
               slug: articleSlug,
             }) => (
-              <Grid
-                item
-                key={`${title}-${slug}`}
-                xs="auto"
-                sm={6}
-                md={6}
-                lg={4}
-              >
+              <Grid item key={`${title}-${slug}`} xs={12} sm={6} md={6} lg={4}>
                 <ArticleCard
                   title={articleTitle}
                   sectionSlug={slug}

--- a/src/templates/Section/Section.js
+++ b/src/templates/Section/Section.js
@@ -25,13 +25,8 @@ const Section = ({
       <div className="wrapper">
         <h2 className="section-headline">{title}</h2>
       </div>
-      <Box my={5} mx="auto" data-testid="sections" maxWidth={1620}>
-        <Grid
-          container
-          justify={justify}
-          spacing={10}
-          data-testid="sectionsGrid"
-        >
+      <Box my={5} mx="20px" data-testid="articles" maxWidth={1620}>
+        <Grid container justify={justify} spacing={5} data-testid="articleGrid">
           {articles.map(
             ({
               title: articleTitle,
@@ -39,7 +34,14 @@ const Section = ({
               previewLinkText,
               slug: articleSlug,
             }) => (
-              <Grid item key={`${title}-${slug}`} xs="auto">
+              <Grid
+                item
+                key={`${title}-${slug}`}
+                xs="auto"
+                sm={6}
+                md={6}
+                lg={4}
+              >
                 <ArticleCard
                   title={articleTitle}
                   sectionSlug={slug}


### PR DESCRIPTION
## Description
The goal to achieve was to implement the article cards that are accessed through the sections.

## Changelog
Mostly this ticket is to add the grid to the cards so they are displayed correctly on the page. Same implementation as SectionCard.

## Checks

- [ ] Responsive on mobile

- [ ] Implementation documented 

- [ ] 80% test coverage

- [ ] Ticket meets all Acceptance Criteria

- [ ] Matches/ aligns to content model

- [ ] Content model diagram updated


## Tested in 
- [ ] Chrome
- [ ] Safari

## Screenshots
![image](https://user-images.githubusercontent.com/6594287/76940106-88380080-68f1-11ea-89c9-e4669c92cb48.png)

![image](https://user-images.githubusercontent.com/6594287/76940117-8ff7a500-68f1-11ea-888f-90a2a34cfa95.png)

![image](https://user-images.githubusercontent.com/6594287/76940140-984fe000-68f1-11ea-9cf5-fc96eac247e2.png)
