### PR TITLE
obfuscate email mailto also added subject and body

### DIFF
--- a/cypress/integration/accessibility.test.js
+++ b/cypress/integration/accessibility.test.js
@@ -4,10 +4,7 @@ const A11Y_OPTIONS = {
     values: ['wcag21aa', 'wcag2aa', 'best-practice', 'section508'],
   },
 }
-const isMasked = content =>
-  content.match(
-    /^obfuscated?/,
-  )
+const isMasked = content => content.match(/obfuscated/)
 
 describe('Accessibility tests', () => {
   it('Has no detectable accessibility violations on load on header links', () => {

--- a/cypress/integration/accessibility.test.js
+++ b/cypress/integration/accessibility.test.js
@@ -4,9 +4,9 @@ const A11Y_OPTIONS = {
     values: ['wcag21aa', 'wcag2aa', 'best-practice', 'section508'],
   },
 }
-const isMailTo = content =>
+const isMasked = content =>
   content.match(
-    /^mailto:([^?]+)\?{0,1}(?:[sS]ubject='([^']*)')?(?:&?[Bb]ody=(.*))?/,
+    /^obfuscated?/,
   )
 
 describe('Accessibility tests', () => {
@@ -24,7 +24,7 @@ describe('Accessibility tests', () => {
     cy.visit('/')
     cy.get('footer a').should('have.length', 4)
     cy.get('footer a').each(item => {
-      if (!isMailTo(item[0].href)) {
+      if (!isMasked(item[0].href)) {
         cy.visit(item[0].href)
           .get('main')
           .injectAxe()

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-helmet-async": "^1.0.4",
+    "react-obfuscate": "^3.6.6",
     "sharp": "^0.24.1"
   },
   "devDependencies": {

--- a/src/components/RichText/MailTo.js
+++ b/src/components/RichText/MailTo.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {string} from 'prop-types'
-
+import Obfuscate from 'react-obfuscate'
 import {makeStyles} from '@material-ui/styles'
 import {Typography} from '@material-ui/core'
 
@@ -15,14 +15,20 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const MailTo = ({label, emailAddress}) => {
+const MailTo = ({label, emailAddress, subject, body}) => {
   const classes = useStyles()
   return (
     <Typography variant="body1">
       {label}
-      <a href={`mailto:${emailAddress}`} className={classes.richTextLink}>
-        {emailAddress}
-      </a>
+      <Obfuscate
+        data-testid="mailto-link"
+        className={classes.richTextLink}
+        email={emailAddress}
+        headers={{
+          subject,
+          body,
+        }}
+      />
     </Typography>
   )
 }
@@ -30,6 +36,12 @@ const MailTo = ({label, emailAddress}) => {
 MailTo.propTypes = {
   label: string.isRequired,
   emailAddress: string.isRequired,
+  subject: string.isRequired,
+  body: string.isRequired,
 }
 
+MailTo.defaultProps = {
+  subject: '',
+  body: '',
+}
 export default MailTo

--- a/src/components/RichText/test/RichText.test.js
+++ b/src/components/RichText/test/RichText.test.js
@@ -1,103 +1,123 @@
 import React from 'react'
 import render from '../../../utils/tests/renderWithTheme'
+import {fireEvent} from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import RichText from '..'
 
-it('should render the component', () => {
-  const props = {
-    className: 'footer__content',
-    text: {
-      json: {
-        data: {},
-        content: [
-          {
-            data: {},
-            content: [
-              {
-                data: {},
-                marks: [],
-                value: '© Houses of Parliament | Restoration and Renewal 2020',
-                nodeType: 'text',
-              },
-            ],
-            nodeType: 'paragraph',
-          },
-          {
-            data: {
-              uri: 'http://google.com',
+const props = {
+  className: 'footer__content',
+  text: {
+    json: {
+      data: {},
+      content: [
+        {
+          data: {},
+          content: [
+            {
+              data: {},
+              marks: [],
+              value: '© Houses of Parliament | Restoration and Renewal 2020',
+              nodeType: 'text',
             },
-            content: [
-              {
-                data: {},
-                marks: [],
-                value: 'Here is an external link',
-                nodeType: 'text',
-              },
-            ],
-            nodeType: 'hyperlink',
+          ],
+          nodeType: 'paragraph',
+        },
+        {
+          data: {
+            uri: 'http://google.com',
           },
-          {
-            data: {
-              target: {
-                sys: {
-                  space: {
-                    sys: {
-                      type: 'Link',
-                      linkType: 'Space',
-                      id: 'h5nvy9gnf018',
-                      contentful_id: 'h5nvy9gnf018',
-                    },
-                  },
-                  id: 'c5Vwn6i40gm8CVuwwnNLW4p',
-                  type: 'Entry',
-                  createdAt: '2020-03-16T14:51:03.777Z',
-                  updatedAt: '2020-03-16T14:51:03.777Z',
-                  environment: {
-                    sys: {
-                      id: 'master',
-                      type: 'Link',
-                      linkType: 'Environment',
-                      contentful_id: 'master',
-                    },
-                  },
-                  revision: 1,
-                  contentType: {
-                    sys: {
-                      type: 'Link',
-                      linkType: 'ContentType',
-                      id: 'mailto',
-                      contentful_id: 'mailto',
-                    },
-                  },
-                  contentful_id: '5Vwn6i40gm8CVuwwnNLW4p',
-                },
-                fields: {
-                  name: {
-                    'en-US': 'Restoration & Renewal',
-                  },
-                  label: {
-                    'en-US':
-                      'Contact the Restoration and Renewal Programme team at ',
-                  },
-                  emailAddress: {
-                    'en-US': 'restorationandrenewal@parliament.uk',
+          content: [
+            {
+              data: {},
+              marks: [],
+              value: 'Here is an external link',
+              nodeType: 'text',
+            },
+          ],
+          nodeType: 'hyperlink',
+        },
+        {
+          data: {
+            target: {
+              sys: {
+                space: {
+                  sys: {
+                    type: 'Link',
+                    linkType: 'Space',
+                    id: 'h5nvy9gnf018',
+                    contentful_id: 'h5nvy9gnf018',
                   },
                 },
+                id: 'c5Vwn6i40gm8CVuwwnNLW4p',
+                type: 'Entry',
+                createdAt: '2020-03-16T14:51:03.777Z',
+                updatedAt: '2020-03-16T14:51:03.777Z',
+                environment: {
+                  sys: {
+                    id: 'master',
+                    type: 'Link',
+                    linkType: 'Environment',
+                    contentful_id: 'master',
+                  },
+                },
+                revision: 1,
+                contentType: {
+                  sys: {
+                    type: 'Link',
+                    linkType: 'ContentType',
+                    id: 'mailto',
+                    contentful_id: 'mailto',
+                  },
+                },
+                contentful_id: '5Vwn6i40gm8CVuwwnNLW4p',
+              },
+              fields: {
+                name: {
+                  'en-US': 'Restoration & Renewal',
+                },
+                label: {
+                  'en-US':
+                    'Contact the Restoration and Renewal Programme team at ',
+                },
+                emailAddress: {
+                  'en-US': 'restorationandrenewal@parliament.uk',
+                },
+                subject: {
+                  'en-US': 'subject',
+                },
+                body: {
+                  'en-US': 'body',
+                },
               },
             },
-            content: [],
-            nodeType: 'embedded-entry-block',
           },
-        ],
-      },
+          content: [],
+          nodeType: 'embedded-entry-block',
+        },
+      ],
     },
-  }
+  },
+}
 
-  const {getByText} = render(<RichText {...props} />)
-  expect(getByText(/Houses of Parliament/g)).toBeDefined()
-  expect(getByText('Here is an external link')).toBeDefined()
-  expect(
-    getByText(/Contact the Restoration and Renewal Programme team at/g),
-  ).toBeDefined()
-  expect(getByText('restorationandrenewal@parliament.uk')).toBeDefined()
+describe('Footer component', () => {
+  it('should render the component', () => {
+    const {getByText} = render(<RichText {...props} />)
+    expect(getByText(/Houses of Parliament/g)).toBeDefined()
+    expect(getByText('Here is an external link')).toBeDefined()
+    expect(
+      getByText(/Contact the Restoration and Renewal Programme team at/g),
+    ).toBeDefined()
+  })
+
+  it('should mask email address', () => {
+    const {getByTestId} = render(<RichText {...props} />)
+    const MailtoLink = getByTestId('mailto-link')
+    expect(MailtoLink).toBeInTheDocument()
+    expect(MailtoLink).toHaveAttribute('href', 'obfuscated')
+    fireEvent.mouseOver(MailtoLink)
+    expect(MailtoLink).toHaveAttribute(
+      'href',
+      'mailto:restorationandrenewal@parliament.uk?subject=subject&body=body',
+    )
+  })
 })


### PR DESCRIPTION
## Description
Adding subject and body into the mailto link
Also masking the url from bots

## Checks

- [x] Responsive on mobile

- [x] Implementation documented 

- [x] 80% test coverage

- [x] Ticket meets all Acceptance Criteria

- [x] Matches/ aligns to content model

- [x] Content model diagram updated


## Tested in 
- [x] Chrome
- [x] Safari

## Screenshots
<img width="1006" alt="2020-03-20_11-33-25" src="https://user-images.githubusercontent.com/1391263/77160154-b73fa500-6a9e-11ea-8955-995b601a7992.png">

