### PR TITLE
Add google tag manager

### DIFF
--- a/__mocks__/react-gtm-module.js
+++ b/__mocks__/react-gtm-module.js
@@ -1,0 +1,3 @@
+module.exports = {
+  initialize: jest.fn(),
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,7 +73,7 @@ exports.createPages = async ({graphql, actions}) => {
 
   articles.forEach(({slug, section: {slug: sectionSlug}}) => {
     const {article} = sections.find(({slug}) => slug === sectionSlug)
-    const articleList = article.map(({slug, sectionSlug, title}) => ({
+    const articleList = article.map(({slug, title}) => ({
       slug: `/${sectionSlug}/${slug}`,
       title,
     }))

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
+    "react-gtm-module": "^2.0.8",
     "react-helmet-async": "^1.0.4",
     "react-obfuscate": "^3.6.6",
     "sharp": "^0.24.1"

--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react'
+import {useEffect} from 'react'
 import TagManager from 'react-gtm-module'
 
 const tagManagerArgs = {
@@ -9,7 +9,7 @@ const Analytics = () => {
   useEffect(() => {
     TagManager.initialize(tagManagerArgs)
   }, [])
-  return <div />
+  return ''
 }
 
 export default Analytics

--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -1,0 +1,15 @@
+import React, {useEffect} from 'react'
+import TagManager from 'react-gtm-module'
+
+const tagManagerArgs = {
+  gtmId: 'GTM-T8M7L77',
+}
+
+const Analytics = () => {
+  useEffect(() => {
+    TagManager.initialize(tagManagerArgs)
+  }, [])
+  return <div />
+}
+
+export default Analytics

--- a/src/components/Analytics/index.js
+++ b/src/components/Analytics/index.js
@@ -1,0 +1,1 @@
+export {default} from './Analytics'

--- a/src/components/Analytics/test/Analytics.test.js
+++ b/src/components/Analytics/test/Analytics.test.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import render from '../../../utils/tests/renderWithTheme'
+import TagManager from 'react-gtm-module'
+
+import Analytics from '..'
+
+it('should render the component', () => {
+  render(<Analytics />)
+  expect(TagManager.initialize).toHaveBeenCalledTimes(1)
+})

--- a/src/components/MainWrapper/MainWrapper.js
+++ b/src/components/MainWrapper/MainWrapper.js
@@ -4,13 +4,17 @@ import {ThemeProvider} from '@material-ui/styles'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import {node} from 'prop-types'
 import theme from '../../utils/theme'
+import Analytics from '../Analytics'
 
-const MainWrapper = ({element}) => (
-  <ThemeProvider theme={theme}>
-    <CssBaseline />
-    {element}
-  </ThemeProvider>
-)
+const MainWrapper = ({element}) => {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Analytics />
+      {element}
+    </ThemeProvider>
+  )
+}
 
 MainWrapper.propTypes = {
   element: node.isRequired,

--- a/src/components/MainWrapper/MainWrapper.js
+++ b/src/components/MainWrapper/MainWrapper.js
@@ -6,15 +6,13 @@ import {node} from 'prop-types'
 import theme from '../../utils/theme'
 import Analytics from '../Analytics'
 
-const MainWrapper = ({element}) => {
-  return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Analytics />
-      {element}
-    </ThemeProvider>
-  )
-}
+const MainWrapper = ({element}) => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    <Analytics />
+    {element}
+  </ThemeProvider>
+)
 
 MainWrapper.propTypes = {
   element: node.isRequired,


### PR DESCRIPTION
## Description
Add GTM within the root element.
GTM will be initialised only the first time the website is loaded and not on page change.
This PR is needed in order to start testing all the different requirements from GTM console, more PRs will follow depending on feedback and change requests.

## Changelog
Description about the modification

## Checks

- [x] Implementation documented 

- [x] 80% test coverage

- [x] Ticket meets all Acceptance Criteria


## Tested in 
- [x] Chrome
- [x] Safari
