### PR TITLE
Fix storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sharp": "^0.24.1"
   },
   "devDependencies": {
-    "@storybook/react": "^5.3.14",
+    "@storybook/addon-knobs": "^5.3.17",
+    "@storybook/react": "^5.3.17",
     "@testing-library/cypress": "^5.3.0",
     "@testing-library/jest-dom": "^5.1.1",
     "@testing-library/react": "^9.4.1",

--- a/scripts/createComponent.js
+++ b/scripts/createComponent.js
@@ -10,13 +10,14 @@ const $CNAME = () => (
 );
 
 export default $CNAME;`
-const componentStoryTemplate = `
-import React from 'react'
+const componentStoryTemplate = `import React from 'react'
+import { storiesOf } from '@storybook/react';
 import $CNAME from '../$CNAME'
 
-export default {title: '$CNAME'}
-
-export const withProps = () => <$CNAME />
+storiesOf('$CNAME', module)
+  .add('$CNAME', () => (
+   <$CNAME />
+  ))
 `
 const componentTestTemplate = `import React from 'react'
 import render from '../../../utils/tests/renderWithTheme'

--- a/src/components/ArticleBanner/stories/ArticleBanner.stories.js
+++ b/src/components/ArticleBanner/stories/ArticleBanner.stories.js
@@ -1,6 +1,11 @@
 import React from 'react'
+import {storiesOf} from '@storybook/react'
 import ArticleBanner from '../ArticleBanner'
+import {text, withKnobs} from '@storybook/addon-knobs'
 
-export default {title: 'ArticleBanner'}
-
-export const withProps = () => <ArticleBanner />
+storiesOf('ArticleBanner', module)
+  .addDecorator(withKnobs)
+  .add('ArticleBanner', () => {
+    const section = {title: text('Title', 'Banner title')}
+    return <ArticleBanner {...section} />
+  })

--- a/src/components/ArticleCard/stories/ArticleCard.stories.js
+++ b/src/components/ArticleCard/stories/ArticleCard.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import ArticleCard from '../ArticleCard'
-
-export default {title: 'ArticleCard'}
-
-export const withProps = () => <ArticleCard />

--- a/src/components/Footer/stories/Footer.stories.js
+++ b/src/components/Footer/stories/Footer.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import Footer from '../Footer'
-
-export default {title: 'Footer'}
-
-export const withProps = () => <Footer />

--- a/src/components/Header/stories/Header.stories.js
+++ b/src/components/Header/stories/Header.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import Header from '../Header'
-
-export default {title: 'Header'}
-
-export const withProps = () => <Header />

--- a/src/components/Hero/stories/Hero.stories.js
+++ b/src/components/Hero/stories/Hero.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import Hero from '../Hero'
-
-export default {title: 'Hero'}
-
-export const withProps = () => <Hero />

--- a/src/components/Layout/stories/Layout.stories.js
+++ b/src/components/Layout/stories/Layout.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import Layout from '../Layout'
-
-export default {title: 'Layout'}
-
-export const withProps = () => <Layout />

--- a/src/components/RichText/stories/RichText.stories.js
+++ b/src/components/RichText/stories/RichText.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import RichText from '../RichText'
-
-export default {title: 'RichText'}
-
-export const withProps = () => <RichText />

--- a/src/components/SEO/stories/SEO.stories.js
+++ b/src/components/SEO/stories/SEO.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import SEO from '../SEO'
-
-export default {title: 'SEO'}
-
-export const withProps = () => <SEO />

--- a/src/components/SectionCard/stories/SectionCard.stories.js
+++ b/src/components/SectionCard/stories/SectionCard.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import SectionCard from '../SectionCard'
-
-export default {title: 'SectionCard'}
-
-export const withProps = () => <SectionCard />

--- a/src/components/SideBar/stories/SideBar.stories.js
+++ b/src/components/SideBar/stories/SideBar.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import SideBar from '../SideBar'
-
-export default {title: 'SideBar'}
-
-export const withProps = () => <SideBar />

--- a/src/templates/Page/stories/Page.stories.js
+++ b/src/templates/Page/stories/Page.stories.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import Page from '../Page'
-
-export default {title: 'Page'}
-
-export const withProps = () => <Page />


### PR DESCRIPTION
## Description
Fixing broken storybook
## Changelog
Refactored the creations script for stories, and removed  those which are broken
## Checks

- [x] Responsive on mobile

- [x] Implementation documented 

- [x] 80% test coverage

- [x] Ticket meets all Acceptance Criteria

- [x] Matches/ aligns to content model

- [x] Content model diagram updated


## Tested in 
- [x] Chrome
- [x] Safari

## Screenshots
The issue was the following
```ERROR in ./node_modules/gatsby/cache-dir/gatsby-browser-entry.js 25:4
Module parse failed: Unexpected token (25:4)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| 
|   return (
>     <React.Fragment>
|       {finalData && render(finalData)}
|       {!finalData && <div>Loading (StaticQuery)</div>}
 @ ./src/components/ArticleCard/ArticleCard.js 6:0-30 86:25-29
 @ ./src/components/ArticleCard/stories/ArticleCard.stories.js
 @ ./src sync ^\.\/(?:(?:(?!\.)(?:(?:(?!(?:|\/)\.).)*?)\/)?(?!\.)(?=.)[^\/]*?\.stories\.js\/?)$
 @ ./.storybook/generated-entry.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/generated-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=true
Child HtmlWebpackCompiler:
                          Asset      Size               Chunks  Chunk Names
    __child-HtmlWebpackPlugin_0  6.35 KiB  HtmlWebpackPlugin_0  HtmlWebpackPlugin_0
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [./node_modules/html-webpack-plugin/lib/loader.js!./node_modules/@storybook/core/dist/server/templates/index.ejs] 2.15 KiB {HtmlWebpackPlugin_0} [built]
WARN Broken build, fix the error above.
WARN You may need to refresh the browser.```