### PR TITLE
:wrench: Updated lint staged config to remove warning

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -3,7 +3,6 @@
     "eslint"
   ],
   "**/*.+(js|json)": [
-    "prettier --write",
-    "git add"
+    "prettier --write"
   ]
 }


### PR DESCRIPTION
Fixes warning: ⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
