### PR TITLE
Location provider

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,7 +74,7 @@ exports.createPages = async ({graphql, actions}) => {
   articles.forEach(({slug, section: {slug: sectionSlug}}) => {
     const {article} = sections.find(({slug}) => slug === sectionSlug)
     const articleList = article.map(({slug, shortTitle: title}) => ({
-      slug: `/${sectionSlug}/${slug}`,
+      slug: `${sectionSlug}/${slug}`,
       title,
     }))
 
@@ -82,6 +82,7 @@ exports.createPages = async ({graphql, actions}) => {
       path: `/${sectionSlug}/${slug}/`,
       component: articleTemplate,
       context: {
+        sectionSlug,
         slug,
         articleList,
       },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.9.0",
+    "classnames": "^2.2.6",
     "filesize": "^6.1.0",
     "gatsby": "^2.19.22",
     "gatsby-image": "^2.2.42",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "create-component": "node ./scripts/createComponent.js",
     "create-template": "node ./scripts/createTemplate.js",
     "create-page": "node ./scripts/createPage.js",
-    "create-hook": "node ./scripts/createHook.js"
+    "create-hook": "node ./scripts/createHook.js",
+    "create-provider": "node ./scripts/createProvider.js"
   }
 }

--- a/scripts/createProvider.js
+++ b/scripts/createProvider.js
@@ -1,0 +1,52 @@
+const {generateProviderContext} = require('./utils')
+
+const fName = process.argv[2]
+
+const indexTemplate = `export {default} from './$CNAMEProvider'`
+
+const contextTemplate = `import {createContext} from 'react'
+
+export default createContext()`
+
+const providerTemplate = `import React from 'react'
+import {node} from 'prop-types'
+
+import $CNAMEContext from './$CNAMEContext'
+
+const {Provider} = $CNAMEContext
+
+const $CNAMEProvider = ({children}) => (
+  <Provider>
+  {
+    children
+  }
+  </Provider>
+);
+
+$CNAMEProvider.propTypes = {
+  children: node.isRequired,
+}
+
+export default $CNAMEProvider;`
+
+const providerTestTemplate = `import React from 'react'
+import {render} from '@testing-library/react'
+
+import $CNAMEProvider from '..'
+
+it('should render the provider', () => {
+  const wrapper = render(<$CNAMEProvider />)
+  expect(false).toEqual(true)
+})`
+
+const {
+  writeContext,
+  writeProvider,
+  writeIndex,
+  writeTest,
+} = generateProviderContext('../src/providers', fName)
+
+writeContext(contextTemplate)
+writeProvider(providerTemplate)
+writeIndex(indexTemplate)
+writeTest(providerTestTemplate)

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,6 +1,9 @@
 const fs = require('fs')
 const path = require('path')
 
+const replaceInTemplate = template => needle =>
+  template.replace(/\$CNAME/g, needle).replace(/\$FNAME/g, needle)
+
 const generateComponentContext = (dir, fName) => {
   const COMPONENTS_DIR = path.resolve(__dirname, dir)
   if (!fs.existsSync(COMPONENTS_DIR)) {
@@ -10,9 +13,6 @@ const generateComponentContext = (dir, fName) => {
   const createTestDir = fName => fs.mkdirSync(`${COMPONENTS_DIR}/${fName}/test`)
   const createStoriesDir = fName =>
     fs.mkdirSync(`${COMPONENTS_DIR}/${fName}/stories`)
-
-  const replaceInTemplate = template => needle =>
-    template.replace(/\$CNAME/g, needle).replace(/\$FNAME/g, needle)
 
   const generateWriteComponent = fName => template =>
     fs.writeFileSync(
@@ -36,6 +36,7 @@ const generateComponentContext = (dir, fName) => {
       'utf8',
     )
   }
+
   const generateWriteStories = fName => template => {
     createStoriesDir(fName)
     return fs.writeFileSync(
@@ -54,6 +55,54 @@ const generateComponentContext = (dir, fName) => {
   }
 }
 
+const generateProviderContext = (dir, fName) => {
+  const COMPONENTS_DIR = path.resolve(__dirname, dir)
+  if (!fs.existsSync(COMPONENTS_DIR)) {
+    fs.mkdirSync(COMPONENTS_DIR)
+  }
+
+  const createDir = fName => fs.mkdirSync(`${COMPONENTS_DIR}/${fName}Provider`)
+  const createTestDir = fName =>
+    fs.mkdirSync(`${COMPONENTS_DIR}/${fName}Provider/test`)
+
+  const generateWriteIndex = fName => template =>
+    fs.writeFileSync(
+      `${COMPONENTS_DIR}/${fName}Provider/index.js`,
+      replaceInTemplate(template)(fName),
+      'utf8',
+    )
+  const generateWriteProvider = fName => template =>
+    fs.writeFileSync(
+      `${COMPONENTS_DIR}/${fName}Provider/${fName}Provider.js`,
+      replaceInTemplate(template)(fName),
+      'utf8',
+    )
+  const generateWriteContext = fName => template =>
+    fs.writeFileSync(
+      `${COMPONENTS_DIR}/${fName}Provider/${fName}Context.js`,
+      replaceInTemplate(template)(fName),
+      'utf8',
+    )
+  const generateWriteTest = fName => template => {
+    createTestDir(fName)
+    return fs.writeFileSync(
+      `${COMPONENTS_DIR}/${fName}Provider/test/${fName}Provider.test.js`,
+      replaceInTemplate(template)(fName),
+      'utf8',
+    )
+  }
+
+  createDir(fName)
+
+  return {
+    writeContext: generateWriteContext(fName),
+    writeProvider: generateWriteProvider(fName),
+    writeIndex: generateWriteIndex(fName),
+    writeTest: generateWriteTest(fName),
+  }
+}
+
 module.exports = {
   generateComponentContext,
+  generateProviderContext,
 }

--- a/src/components/Header/Menu.js
+++ b/src/components/Header/Menu.js
@@ -1,9 +1,12 @@
 import React from 'react'
+import classNames from 'classnames'
+
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
 import {Link} from 'gatsby'
 import {arrayOf, shape, string} from 'prop-types'
 import {makeStyles} from '@material-ui/core/styles'
+import useLocation from '../../hooks/useLocation'
 
 const useStyles = makeStyles(theme => ({
   link: {
@@ -23,14 +26,17 @@ const useStyles = makeStyles(theme => ({
 
 const Menu = ({sections}) => {
   const classes = useStyles()
+  const {section} = useLocation()
+
   return (
     <Grid container spacing={3} style={{width: 'calc(100% + 25px)'}}>
       {sections.map(({name, slug}) => (
         <Grid item key={name} xs={12} sm={12} md="auto">
           <Link
             to={`/${slug}`}
-            className={classes.link}
-            activeClassName={classes.activeLink}
+            className={classNames(classes.link, {
+              [classes.activeLink]: slug === section,
+            })}
             data-cy="navigation-link"
           >
             <Typography variant="h6">{name}</Typography>

--- a/src/components/Header/test/Header.test.js
+++ b/src/components/Header/test/Header.test.js
@@ -6,8 +6,8 @@ import render from '../../../utils/tests/renderWithTheme'
 import Header from '..'
 import mockIsMobile from '../../../stubs/mockIsMobile'
 import mockHeader from '../../../stubs/mockHeader'
-
 import headerData from '../../../stubs/headerData'
+import LocationProvider from '../../../providers/LocationProvider'
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -15,20 +15,48 @@ beforeEach(() => {
 
 test('should render the component', () => {
   mockHeader()
-  const {getByAltText, getByText} = render(<Header />)
-  headerData.contentfulHeader.sections.forEach(({name}) => {
+  const {getByAltText, getByText} = render(
+    <LocationProvider>
+      <Header />
+    </LocationProvider>,
+  )
+  headerData.contentfulHeader.sections.forEach(({name, slug}) => {
     const section = getByText(name)
     expect(section).toBeDefined()
-    expect(section.parentNode).toHaveAttribute('href', '/palace')
+    expect(section.parentNode).toHaveAttribute('href', `/${slug}`)
   })
   const logo = getByAltText(headerData.contentfulHeader.logo.title)
   expect(logo).toBeDefined()
 })
 
+test('should highlight the current section', () => {
+  mockHeader()
+  const {getByText} = render(
+    <LocationProvider section="palace">
+      <Header />
+    </LocationProvider>,
+  )
+  headerData.contentfulHeader.sections.forEach(({name, slug}) => {
+    const section = getByText(name)
+    expect(section).toBeDefined()
+    expect(section.parentNode).toHaveAttribute('href', `/${slug}`)
+    const sectionStyles = window.getComputedStyle(section)
+    if (slug === 'palace') {
+      expect(sectionStyles['border-bottom']).toEqual('5px solid')
+    } else {
+      expect(sectionStyles['border-bottom']).toEqual('')
+    }
+  })
+})
+
 test('should show the hamburger menu, open and close it', async () => {
   mockHeader()
   mockIsMobile()
-  const {queryByText, queryByTestId} = render(<Header />)
+  const {queryByText, queryByTestId} = render(
+    <LocationProvider>
+      <Header />
+    </LocationProvider>,
+  )
   const mobileMenu = queryByTestId('mobileMenu')
   expect(mobileMenu).toBeDefined()
   headerData.contentfulHeader.sections.forEach(({name}) => {

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -6,6 +6,7 @@ import Box from '@material-ui/core/Box'
 import theme from '../../utils/theme'
 import {makeStyles, ThemeProvider} from '@material-ui/core/styles'
 import SEO from '../SEO'
+import LocationProvider from '../../providers/LocationProvider'
 
 const useStyles = makeStyles(theme => ({
   body: {
@@ -16,10 +17,14 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const Layout = ({title, children}) => {
+const Layout = ({title, children, section, article, childArticle}) => {
   const classes = useStyles()
   return (
-    <>
+    <LocationProvider
+      section={section}
+      article={article}
+      childArticle={childArticle}
+    >
       <SEO title={title} />
       <ThemeProvider theme={theme}>
         <Box component="main" className={classes.body}>
@@ -28,12 +33,15 @@ const Layout = ({title, children}) => {
           <Footer />
         </Box>
       </ThemeProvider>
-    </>
+    </LocationProvider>
   )
 }
 
 Layout.propTypes = {
   title: string.isRequired,
+  section: string,
+  article: string,
+  childArticle: string,
   children: node.isRequired,
 }
 

--- a/src/components/Layout/LayoutContext.js
+++ b/src/components/Layout/LayoutContext.js
@@ -1,0 +1,2 @@
+import {createContext} from 'react'
+export default createContext()

--- a/src/components/SideBar/SideBarMenu.js
+++ b/src/components/SideBar/SideBarMenu.js
@@ -1,9 +1,12 @@
 import React from 'react'
+import classNames from 'classnames'
+
 import Typography from '@material-ui/core/Typography'
 import {Link} from 'gatsby'
 import {arrayOf, shape, string} from 'prop-types'
 import {makeStyles} from '@material-ui/core/styles'
 import Box from '@material-ui/core/Box'
+import useLocation from '../../hooks/useLocation'
 
 const useStyles = makeStyles(theme => ({
   wrapper: {
@@ -40,6 +43,7 @@ const useStyles = makeStyles(theme => ({
 
 const SideBarMenu = ({articleList}) => {
   const classes = useStyles()
+  const {article} = useLocation()
   return (
     <Box className={classes.wrapper}>
       <ul className={classes.list}>
@@ -47,7 +51,9 @@ const SideBarMenu = ({articleList}) => {
           <li key={slug} className={classes.listItem}>
             <Link
               to={`/${slug}`}
-              className={classes.link}
+              className={classNames(classes.link, {
+                [classes.activeLink]: slug === article,
+              })}
               activeClassName={classes.activeLink}
             >
               <Typography className={classes.linkText}>{title}</Typography>

--- a/src/components/SideBar/test/SideBar.test.js
+++ b/src/components/SideBar/test/SideBar.test.js
@@ -5,6 +5,7 @@ import mockIsMobile from '../../../stubs/mockIsMobile'
 import '@testing-library/jest-dom/extend-expect'
 
 import SideBar from '..'
+import LocationProvider from '../../../providers/LocationProvider'
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -19,7 +20,11 @@ const articleList = [
 ]
 
 it('should render the correct article names', () => {
-  const {getAllByText} = render(<SideBar articleList={articleList} />)
+  const {getAllByText} = render(
+    <LocationProvider>
+      <SideBar articleList={articleList} />
+    </LocationProvider>,
+  )
 
   articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
@@ -32,7 +37,11 @@ it('should render the correct article names', () => {
 
 it('should render the mobile menu properly and open and close it', async () => {
   mockIsMobile()
-  const {getByTestId} = render(<SideBar articleList={articleList} />)
+  const {getByTestId} = render(
+    <LocationProvider>
+      <SideBar articleList={articleList} />
+    </LocationProvider>,
+  )
   const menuHeader = getByTestId('sidebarMobileMenu')
   expect(menuHeader).toBeDefined()
   fireEvent.click(menuHeader)
@@ -41,4 +50,25 @@ it('should render the mobile menu properly and open and close it', async () => {
   fireEvent.click(menuHeader)
   const openMenu = await waitForElement(() => getByTestId('openMenuIcon'))
   expect(openMenu).toBeDefined()
+})
+
+it('should highlight the current article page', () => {
+  const currentArticle = {
+    slug: 'current_article',
+    title: 'current article',
+  }
+
+  const {getAllByText} = render(
+    <LocationProvider article="current_article">
+      <SideBar articleList={[...articleList, currentArticle]} />
+    </LocationProvider>,
+  )
+  const articleElement = getAllByText(articleList[0].title)[1]
+  const currentArticleElement = getAllByText(currentArticle.title)[1]
+  const articleStyles = window.getComputedStyle(articleElement.parentNode)
+  const currentArticleStyles = window.getComputedStyle(
+    currentArticleElement.parentNode,
+  )
+  expect(articleStyles['border-left']).toEqual('')
+  expect(currentArticleStyles['border-left']).toEqual('4px solid #6B609C')
 })

--- a/src/hooks/useLocation/index.js
+++ b/src/hooks/useLocation/index.js
@@ -1,0 +1,1 @@
+export {default} from './useLocation'

--- a/src/hooks/useLocation/useLocation.js
+++ b/src/hooks/useLocation/useLocation.js
@@ -1,0 +1,7 @@
+import {useContext} from 'react'
+import LocationContext from '../../providers/LocationProvider/LocationContext'
+
+export default () => {
+  const location = useContext(LocationContext)
+  return location
+}

--- a/src/providers/LocationProvider/LocationContext.js
+++ b/src/providers/LocationProvider/LocationContext.js
@@ -1,0 +1,3 @@
+import {createContext} from 'react'
+
+export default createContext()

--- a/src/providers/LocationProvider/LocationProvider.js
+++ b/src/providers/LocationProvider/LocationProvider.js
@@ -1,0 +1,49 @@
+import React, {useState} from 'react'
+import {node, string} from 'prop-types'
+
+import LocationContext from './LocationContext'
+
+const {Provider} = LocationContext
+
+const LocationProvider = ({
+  section: defaultSection,
+  article: defaultArticle,
+  childArticle: defaultChildArticle,
+  children,
+}) => {
+  const [location, setLocation] = useState({
+    section: defaultSection,
+    article: defaultArticle,
+    childArticle: defaultChildArticle,
+  })
+
+  const {section, article, childArticle} = location
+
+  return (
+    <Provider
+      value={{
+        section,
+        article,
+        childArticle,
+        setLocation,
+      }}
+    >
+      {children}
+    </Provider>
+  )
+}
+
+LocationProvider.propTypes = {
+  children: node.isRequired,
+  section: string,
+  article: string,
+  childArticle: string,
+}
+
+LocationProvider.defaultProps = {
+  section: '',
+  article: '',
+  childArticle: '',
+}
+
+export default LocationProvider

--- a/src/providers/LocationProvider/LocationProvider.js
+++ b/src/providers/LocationProvider/LocationProvider.js
@@ -1,37 +1,21 @@
-import React, {useState} from 'react'
+import React from 'react'
 import {node, string} from 'prop-types'
 
 import LocationContext from './LocationContext'
 
 const {Provider} = LocationContext
 
-const LocationProvider = ({
-  section: defaultSection,
-  article: defaultArticle,
-  childArticle: defaultChildArticle,
-  children,
-}) => {
-  const [location, setLocation] = useState({
-    section: defaultSection,
-    article: defaultArticle,
-    childArticle: defaultChildArticle,
-  })
-
-  const {section, article, childArticle} = location
-
-  return (
-    <Provider
-      value={{
-        section,
-        article,
-        childArticle,
-        setLocation,
-      }}
-    >
-      {children}
-    </Provider>
-  )
-}
+const LocationProvider = ({section, article, childArticle, children}) => (
+  <Provider
+    value={{
+      section,
+      article,
+      childArticle,
+    }}
+  >
+    {children}
+  </Provider>
+)
 
 LocationProvider.propTypes = {
   children: node.isRequired,

--- a/src/providers/LocationProvider/index.js
+++ b/src/providers/LocationProvider/index.js
@@ -1,0 +1,1 @@
+export {default} from './LocationProvider'

--- a/src/providers/LocationProvider/test/Location.test.js
+++ b/src/providers/LocationProvider/test/Location.test.js
@@ -1,0 +1,48 @@
+import React, {useContext} from 'react'
+import {render} from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import LocationProvider from '..'
+import LocationContext from '../LocationContext'
+
+const Component = () => {
+  const {section, article, childArticle} = useContext(LocationContext)
+  return (
+    <>
+      <p>
+        <span>section</span>
+        <span data-testid="section">{section}</span>
+      </p>
+      <p>
+        <span>article</span>
+        <span data-testid="article">{article}</span>
+      </p>
+      <p>
+        <span>child article</span>
+        <span data-testid="child-article">{childArticle}</span>
+      </p>
+    </>
+  )
+}
+
+it('should have empty section, article and child article by default', () => {
+  const {queryByTestId} = render(
+    <LocationProvider>
+      <Component />
+    </LocationProvider>,
+  )
+  expect(queryByTestId('section')).toBeEmpty()
+  expect(queryByTestId('article')).toBeEmpty()
+  expect(queryByTestId('child-article')).toBeEmpty()
+})
+
+it('should return section, article and child article name', () => {
+  const {getByText} = render(
+    <LocationProvider section="palace" article="history" childArticle="reports">
+      <Component />
+    </LocationProvider>,
+  )
+  expect(getByText('palace')).toBeDefined()
+  expect(getByText('history')).toBeDefined()
+  expect(getByText('reports')).toBeDefined()
+})

--- a/src/stubs/headerData.js
+++ b/src/stubs/headerData.js
@@ -13,6 +13,10 @@ export default {
         name: 'Palace',
         slug: 'palace',
       },
+      {
+        name: 'News',
+        slug: 'news',
+      },
     ],
     homePageLinkText: 'go back to home page',
     logo: {

--- a/src/templates/Article/Article.js
+++ b/src/templates/Article/Article.js
@@ -32,7 +32,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 const Article = ({
-  pageContext: {articleList},
+  pageContext: {slug, sectionSlug, articleList},
   data: {
     contentfulArticle: {
       title,
@@ -43,7 +43,12 @@ const Article = ({
 }) => {
   const classes = useStyles()
   return (
-    <Layout title={title} className={classes.root}>
+    <Layout
+      title={title}
+      className={classes.root}
+      section={sectionSlug}
+      article={slug}
+    >
       <ArticleBanner {...section} />
       <Box
         maxWidth={1620}
@@ -87,6 +92,8 @@ Article.propTypes = {
     }).isRequired,
   }).isRequired,
   pageContext: shape({
+    slug: string.isRequired,
+    sectionSlug: string.isRequired,
     articleList: arrayOf(
       shape({
         title: string.isRequired,

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -15,6 +15,8 @@ const pageContext = {
       slug: '/history/article-1',
     },
   ],
+  slug: 'article',
+  sectionSlug: 'section',
 }
 
 test('should render title amd sidebar menu containing a list of articles', async () => {

--- a/src/templates/Section/Section.js
+++ b/src/templates/Section/Section.js
@@ -14,7 +14,7 @@ const Section = ({
   },
 }) => {
   return (
-    <Layout title={title}>
+    <Layout title={title} section={slug}>
       <Hero {...hero} />
       <Box
         my={5}


### PR DESCRIPTION
## Description
At the moment, when in an article page, the section label in the header is not highlighted anymore, because it only relies on gatsby `Link` component that checks only if the current path corresponds at the `to` attribute.

Add a Location provider so that each Section and Article pages can pass slugs as props to the provider in order to highlight sections and articles.
SideBar and Menu uses the LocationContext to retrieve the right data.
This works on server side rendering

## Checks

- [x] Responsive on mobile

- [x] Implementation documented 

- [x] 80% test coverage

## Tested in 
- [x] Chrome
- [x] Safari
