### PR TITLE
Feature/rr 35 links in rich text

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -72,24 +72,20 @@ exports.createPages = async ({graphql, actions}) => {
     })
   })
 
-  articles.forEach(({slug, section}) => {
-    const {article} = sections.find(({slug}) => slug === section.slug)
+  articles.forEach(({slug, section: {slug: sectionSlug}}) => {
+    const {article} = sections.find(({slug}) => slug === sectionSlug)
     const articleList = article.map(({slug, shortTitle: title}) => ({
-      slug: `${section.slug}/${slug}`,
+      slug: `${sectionSlug}/${slug}`,
       title,
     }))
-    const parentSection = {
-      ...section,
-      slug: `/${section.slug}`,
-    }
 
     createPage({
-      path: `/${section.slug}/${slug}/`,
+      path: `/${sectionSlug}/${slug}/`,
       component: articleTemplate,
       context: {
+        sectionSlug,
         slug,
         articleList,
-        parentSection,
       },
     })
   })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,6 +34,7 @@ exports.createPages = async ({graphql, actions}) => {
             node {
               slug
               section {
+                title
                 slug
               }
             }
@@ -71,19 +72,24 @@ exports.createPages = async ({graphql, actions}) => {
     })
   })
 
-  articles.forEach(({slug, section: {slug: sectionSlug}}) => {
-    const {article} = sections.find(({slug}) => slug === sectionSlug)
+  articles.forEach(({slug, section}) => {
+    const {article} = sections.find(({slug}) => slug === section.slug)
     const articleList = article.map(({slug, shortTitle: title}) => ({
-      slug: `/${sectionSlug}/${slug}`,
+      slug: `/${section.slug}/${slug}`,
       title,
     }))
+    const parentSection = {
+      ...section,
+      slug: `/${section.slug}`,
+    }
 
     createPage({
-      path: `/${sectionSlug}/${slug}/`,
+      path: `/${section.slug}/${slug}/`,
       component: articleTemplate,
       context: {
         slug,
         articleList,
+        parentSection,
       },
     })
   })

--- a/src/components/ArticleCard/ArticleCard.js
+++ b/src/components/ArticleCard/ArticleCard.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {string, object, shape} from 'prop-types'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import Typography from '@material-ui/core/Typography'
 import RichText from '../RichText/RichText'
 import Paper from '@material-ui/core/Paper'
@@ -74,11 +74,14 @@ const ArticleCard = ({title, previewText, linkText, slug, sectionSlug}) => {
             />
           </Box>
           <Box className={classes.linkWrapper}>
-            <Link to={`/${sectionSlug}/${slug}`} className={classes.link}>
+            <LinkHandler
+              url={`/${sectionSlug}/${slug}`}
+              className={classes.link}
+            >
               <Typography variant="body2">
                 {linkText} <ArrowForwardIcon className={classes.arrowIcon} />
               </Typography>
-            </Link>
+            </LinkHandler>
           </Box>
         </Box>
       </Paper>

--- a/src/components/Breadcrumbs/BreadcrumbLink.js
+++ b/src/components/Breadcrumbs/BreadcrumbLink.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {node} from 'prop-types'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import {makeStyles} from '@material-ui/core/styles'
 
 const useStyles = makeStyles(theme => ({
@@ -12,9 +12,9 @@ const useStyles = makeStyles(theme => ({
 const BreadcrumbLink = ({children, ...props}) => {
   const styles = useStyles()
   return (
-    <Link {...props} className={styles.breadcrumbLink}>
+    <LinkHandler {...props} className={styles.breadcrumbLink}>
       {children}
-    </Link>
+    </LinkHandler>
   )
 }
 

--- a/src/components/Breadcrumbs/DesktopBreadcrumbs.js
+++ b/src/components/Breadcrumbs/DesktopBreadcrumbs.js
@@ -7,12 +7,12 @@ import BreadcrumbLink from './BreadcrumbLink'
 const DesktopBreadcrumbs = ({breadcrumbs, dividerCharacter, homepageText}) => (
   <Box>
     <Typography variant="body1">
-      <BreadcrumbLink to="/">{homepageText}</BreadcrumbLink>
+      <BreadcrumbLink url="/">{homepageText}</BreadcrumbLink>
       {breadcrumbs &&
         breadcrumbs.map(breadcrumb => (
           <span key={breadcrumb.slug}>
             <span> {dividerCharacter} </span>
-            <BreadcrumbLink to={breadcrumb.slug}>
+            <BreadcrumbLink url={breadcrumb.slug}>
               {breadcrumb.title}
             </BreadcrumbLink>
           </span>

--- a/src/components/Breadcrumbs/DesktopBreadcrumbs.js
+++ b/src/components/Breadcrumbs/DesktopBreadcrumbs.js
@@ -12,7 +12,7 @@ const DesktopBreadcrumbs = ({breadcrumbs, dividerCharacter, homepageText}) => (
         breadcrumbs.map(breadcrumb => (
           <span key={breadcrumb.slug}>
             <span> {dividerCharacter} </span>
-            <BreadcrumbLink url={breadcrumb.slug}>
+            <BreadcrumbLink url={`/${breadcrumb.slug}`}>
               {breadcrumb.title}
             </BreadcrumbLink>
           </span>

--- a/src/components/Breadcrumbs/MobileBreadcrumbs.js
+++ b/src/components/Breadcrumbs/MobileBreadcrumbs.js
@@ -11,7 +11,7 @@ const MobileBreadcrumbs = ({breadcrumbs, backText}) => {
       <Box>
         <Typography variant="body1">
           <span>{backText}</span>
-          <BreadcrumbLink url={lastBreadcrumb.slug}>
+          <BreadcrumbLink url={`/${lastBreadcrumb.slug}`}>
             {lastBreadcrumb.title}
           </BreadcrumbLink>
         </Typography>

--- a/src/components/Breadcrumbs/MobileBreadcrumbs.js
+++ b/src/components/Breadcrumbs/MobileBreadcrumbs.js
@@ -11,7 +11,7 @@ const MobileBreadcrumbs = ({breadcrumbs, backText}) => {
       <Box>
         <Typography variant="body1">
           <span>{backText}</span>
-          <BreadcrumbLink to={lastBreadcrumb.slug}>
+          <BreadcrumbLink url={lastBreadcrumb.slug}>
             {lastBreadcrumb.title}
           </BreadcrumbLink>
         </Typography>

--- a/src/components/Footer/FooterLinks.js
+++ b/src/components/Footer/FooterLinks.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {shape, string, arrayOf} from 'prop-types'
 import Grid from '@material-ui/core/Grid'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import Typography from '@material-ui/core/Typography'
 import {makeStyles} from '@material-ui/core/styles'
 
@@ -30,14 +30,14 @@ const FooterLinks = ({pages}) => {
     <Grid container spacing={3} direction="row" className={classes.linkWrapper}>
       {pages.map(({name, slug}) => (
         <Grid item key={name} xs={12} sm="auto">
-          <Link
-            to={`/${slug}`}
+          <LinkHandler
+            url={`/${slug}`}
             data-testid={`footer-link-${name}`}
             data-cy="footer-link"
             className={classes.footerMenuLink}
           >
             <Typography variant="body1">{name}</Typography>
-          </Link>
+          </LinkHandler>
         </Grid>
       ))}
     </Grid>

--- a/src/components/Header/FooterLinks.js
+++ b/src/components/Header/FooterLinks.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {arrayOf, shape, string} from 'prop-types'
 import Grid from '@material-ui/core/Grid'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import Typography from '@material-ui/core/Typography'
 import {makeStyles} from '@material-ui/core/styles'
 
@@ -35,15 +35,15 @@ const FooterLinksComponent = ({pages}) => {
     >
       {pages.map(({name, slug}) => (
         <Grid item key={name} xs={12} sm="auto">
-          <Link
-            to={`/${slug}`}
+          <LinkHandler
+            url={`/${slug}`}
             data-testid={`footer-link-${name}`}
             className={classes.hamburgerMenuLink}
           >
             <Typography variant="body1" className={classes.hamburgerMenuText}>
               {name}
             </Typography>
-          </Link>
+          </LinkHandler>
         </Grid>
       ))}
     </Grid>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {useStaticQuery, graphql, Link} from 'gatsby'
+import {useStaticQuery, graphql} from 'gatsby'
 import {shape, string, object, arrayOf} from 'prop-types'
 import Image from 'gatsby-image'
 import {makeStyles, useTheme} from '@material-ui/core/styles'
@@ -9,6 +9,7 @@ import DesktopWrapper from './DesktopWrapper'
 import MobileWrapper from './MobileWrapper'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import Menu from './Menu'
+import LinkHandler from '../LinkHandler'
 
 const styles = makeStyles(theme => ({
   root: {
@@ -85,9 +86,13 @@ const HeaderComponent = ({
         margin="auto"
         className={classes.box}
       >
-        <Link to="/" className={classes.linkBox} aria-label={homePageLinkText}>
+        <LinkHandler
+          url="/"
+          className={classes.linkBox}
+          aria-label={homePageLinkText}
+        >
           <Image fluid={fluid} alt={title} className={classes.logo} />
-        </Link>
+        </LinkHandler>
         <Wrapper footerLinks={pages}>
           <Menu sections={sections} />
         </Wrapper>

--- a/src/components/Header/Menu.js
+++ b/src/components/Header/Menu.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import {arrayOf, shape, string} from 'prop-types'
 import {makeStyles} from '@material-ui/core/styles'
 
@@ -27,14 +27,14 @@ const Menu = ({sections}) => {
     <Grid container spacing={3} style={{width: 'calc(100% + 25px)'}}>
       {sections.map(({name, slug}) => (
         <Grid item key={name} xs={12} sm={12} md="auto">
-          <Link
-            to={`/${slug}`}
+          <LinkHandler
+            url={`/${slug}`}
             className={classes.link}
             activeClassName={classes.activeLink}
             data-cy="navigation-link"
           >
             <Typography variant="h6">{name}</Typography>
-          </Link>
+          </LinkHandler>
         </Grid>
       ))}
     </Grid>

--- a/src/components/LinkHandler/LinkHandler.js
+++ b/src/components/LinkHandler/LinkHandler.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {Link} from 'gatsby'
 
 const LinkHandler = ({url, newTab, children, ...props}) => {
-  if (url.startsWith('/')) {
+  if (/^\/(?!\/)/.test(url)) {
     return (
       <Link to={url} {...props}>
         {children}

--- a/src/components/LinkHandler/LinkHandler.js
+++ b/src/components/LinkHandler/LinkHandler.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Link} from 'gatsby'
+
+const LinkHandler = ({url, newTab, children, ...props}) => {
+  if (url.startsWith('/')) {
+    return (
+      <Link to={url} {...props}>
+        {children}
+      </Link>
+    )
+  }
+  return newTab ? (
+    <a href={url} target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  ) : (
+    <a href={url} {...props}>
+      {children}
+    </a>
+  )
+}
+
+LinkHandler.propTypes = {
+  url: PropTypes.string.isRequired,
+  newTab: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+LinkHandler.defaultProps = {
+  children: null,
+  newTab: false,
+}
+
+export default LinkHandler

--- a/src/components/LinkHandler/LinkHandler.js
+++ b/src/components/LinkHandler/LinkHandler.js
@@ -2,10 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Link} from 'gatsby'
 
-const LinkHandler = ({url, newTab, children, ...props}) => {
+const LinkHandler = ({url, newTab, children, activeclassname, ...props}) => {
   if (/^\/(?!\/)/.test(url)) {
     return (
-      <Link to={url} {...props}>
+      <Link
+        to={url}
+        {...props}
+        activeClassName={activeclassname ? activeclassname : null}
+      >
         {children}
       </Link>
     )
@@ -24,6 +28,7 @@ const LinkHandler = ({url, newTab, children, ...props}) => {
 LinkHandler.propTypes = {
   url: PropTypes.string.isRequired,
   newTab: PropTypes.bool,
+  activeclassname: PropTypes.string,
   children: PropTypes.node,
 }
 

--- a/src/components/LinkHandler/LinkHandler.js
+++ b/src/components/LinkHandler/LinkHandler.js
@@ -2,14 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Link} from 'gatsby'
 
-const LinkHandler = ({url, newTab, children, activeclassname, ...props}) => {
+const LinkHandler = ({url, newTab, children, ...props}) => {
   if (/^\/(?!\/)/.test(url)) {
     return (
-      <Link
-        to={url}
-        {...props}
-        activeClassName={activeclassname ? activeclassname : null}
-      >
+      <Link to={url} {...props}>
         {children}
       </Link>
     )
@@ -28,7 +24,6 @@ const LinkHandler = ({url, newTab, children, activeclassname, ...props}) => {
 LinkHandler.propTypes = {
   url: PropTypes.string.isRequired,
   newTab: PropTypes.bool,
-  activeclassname: PropTypes.string,
   children: PropTypes.node,
 }
 

--- a/src/components/LinkHandler/index.js
+++ b/src/components/LinkHandler/index.js
@@ -1,0 +1,1 @@
+export {default} from './LinkHandler'

--- a/src/components/LinkHandler/test/LinkHandler.test.js
+++ b/src/components/LinkHandler/test/LinkHandler.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import * as Gatsby from 'gatsby'
+import render from '../../../utils/tests/renderWithTheme'
+import '@testing-library/jest-dom/extend-expect'
+import LinkHandler from '../LinkHandler'
+
+const gatsbyLinkSpy = jest.spyOn(Gatsby, 'Link')
+
+describe('Link Handler', () => {
+  beforeEach(() => {
+    gatsbyLinkSpy.mockClear()
+  })
+
+  it('Internal links use Gatbsy Link', () => {
+    render(<LinkHandler url="/internal-link" />)
+    expect(gatsbyLinkSpy).toHaveBeenCalled()
+  })
+
+  it('External links use an a tag and open in same tab without new tab prop', () => {
+    const {container} = render(<LinkHandler url="www.external-link.com" />)
+    const aTag = container.querySelector('a')
+    expect(aTag).toBeDefined()
+    expect(aTag).not.toHaveAttribute('target', '_blank')
+    expect(aTag).not.toHaveAttribute('rel', 'noopener noreferrer')
+    expect(gatsbyLinkSpy).not.toHaveBeenCalled()
+  })
+
+  it('Passing new tab makes External links open in a new tab', () => {
+    const {container} = render(
+      <LinkHandler url="www.external-link.com" newTab />,
+    )
+    const aTag = container.querySelector('a')
+    expect(aTag).toBeDefined()
+    expect(aTag).toHaveAttribute('target', '_blank')
+    expect(aTag).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(gatsbyLinkSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/RichText/FileLink.js
+++ b/src/components/RichText/FileLink.js
@@ -3,6 +3,7 @@ import {string, number} from 'prop-types'
 import {makeStyles} from '@material-ui/styles'
 import {Typography} from '@material-ui/core'
 import displayWithUnits from 'filesize'
+import LinkHandler from '../LinkHandler'
 
 const useStyles = makeStyles(theme => ({
   link: {
@@ -36,11 +37,11 @@ const FileLink = ({title, url, contentType, size}) => {
   const fileSize = formatFileSize(size)
   return (
     <>
-      <a href={url} className={classes.link}>
+      <LinkHandler newTab url={url} className={classes.link}>
         <Typography variant="body1" className={classes.linkText}>
           {title}
         </Typography>
-      </a>
+      </LinkHandler>
       <Typography className={classes.fileInfo}>
         {fileType}, {fileSize}
       </Typography>

--- a/src/components/RichText/RichText.js
+++ b/src/components/RichText/RichText.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {shape, string, object} from 'prop-types'
 import {documentToReactComponents} from '@contentful/rich-text-react-renderer'
 import {INLINES, BLOCKS} from '@contentful/rich-text-types'
-import ExternalLink from './ExternalLink'
+import RichTextLink from './RichTextLink'
 import Paragraph from './Paragraph'
 import EmbeddedComponent from './EmbeddedEntry'
 import EmbeddedAsset from './EmbeddedAsset'
@@ -16,7 +16,7 @@ import HeadingSix from './HeadingSix'
 const RichText = ({className, text}) => {
   const options = {
     renderNode: {
-      [INLINES.HYPERLINK]: ExternalLink,
+      [INLINES.HYPERLINK]: RichTextLink,
       [BLOCKS.PARAGRAPH]: Paragraph,
       [BLOCKS.HEADING_1]: HeadingOne,
       [BLOCKS.HEADING_2]: HeadingTwo,

--- a/src/components/RichText/RichTextLink.js
+++ b/src/components/RichText/RichTextLink.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {arrayOf, shape, string} from 'prop-types'
-
+import LinkHandler from '../LinkHandler'
 import {makeStyles} from '@material-ui/styles'
 
 const useStyles = makeStyles(theme => ({
@@ -14,16 +14,16 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const ExternalLink = ({data: {uri}, content: [{value: text}]}) => {
+const RichTextLink = ({data: {uri}, content: [{value: text}]}) => {
   const classes = useStyles()
   return (
-    <a href={uri} className={classes.richTextLink}>
+    <LinkHandler url={uri} className={classes.richTextLink}>
       {text}
-    </a>
+    </LinkHandler>
   )
 }
 
-ExternalLink.propTypes = {
+RichTextLink.propTypes = {
   data: shape({
     uri: string.isRequired,
   }).isRequired,
@@ -34,4 +34,4 @@ ExternalLink.propTypes = {
   ).isRequired,
 }
 
-export default ExternalLink
+export default RichTextLink

--- a/src/components/RichText/RichTextLink.js
+++ b/src/components/RichText/RichTextLink.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
 const RichTextLink = ({data: {uri}, content: [{value: text}]}) => {
   const classes = useStyles()
   return (
-    <LinkHandler url={uri} className={classes.richTextLink}>
+    <LinkHandler newTab url={uri} className={classes.richTextLink}>
       {text}
     </LinkHandler>
   )

--- a/src/components/SectionCard/SectionCard.js
+++ b/src/components/SectionCard/SectionCard.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shape, object, string} from 'prop-types'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import Image from 'gatsby-image'
 import Typography from '@material-ui/core/Typography'
 import RichText from '../RichText/RichText'
@@ -88,11 +88,11 @@ const SectionCard = ({
             />
           </Box>
           <Box className={classes.linkWrapper}>
-            <Link className={classes.link} to={`/${slug}`}>
+            <LinkHandler className={classes.link} url={`/${slug}`}>
               <Typography variant="body2">
                 {linkText} <ArrowForwardIcon className={classes.arrowIcon} />
               </Typography>
-            </Link>
+            </LinkHandler>
           </Box>
         </Box>
       </Paper>

--- a/src/components/SideBar/SideBarMenu.js
+++ b/src/components/SideBar/SideBarMenu.js
@@ -46,7 +46,7 @@ const SideBarMenu = ({articleList}) => {
         {articleList.map(({title, slug}) => (
           <li key={slug} className={classes.listItem}>
             <LinkHandler
-              url={`/${slug}`}
+              url={slug}
               className={classes.link}
               activeClassName={classes.activeLink}
             >

--- a/src/components/SideBar/SideBarMenu.js
+++ b/src/components/SideBar/SideBarMenu.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Typography from '@material-ui/core/Typography'
-import {Link} from 'gatsby'
+import LinkHandler from '../LinkHandler'
 import {arrayOf, shape, string} from 'prop-types'
 import {makeStyles} from '@material-ui/core/styles'
 import Box from '@material-ui/core/Box'
@@ -45,13 +45,13 @@ const SideBarMenu = ({articleList}) => {
       <ul className={classes.list}>
         {articleList.map(({title, slug}) => (
           <li key={slug} className={classes.listItem}>
-            <Link
-              to={`/${slug}`}
+            <LinkHandler
+              url={`/${slug}`}
               className={classes.link}
               activeClassName={classes.activeLink}
             >
               <Typography className={classes.linkText}>{title}</Typography>
-            </Link>
+            </LinkHandler>
           </li>
         ))}
       </ul>

--- a/src/components/SideBar/SideBarMenu.js
+++ b/src/components/SideBar/SideBarMenu.js
@@ -48,7 +48,7 @@ const SideBarMenu = ({articleList}) => {
             <LinkHandler
               url={slug}
               className={classes.link}
-              activeClassName={classes.activeLink}
+              activeclassname={classes.activeLink}
             >
               <Typography className={classes.linkText}>{title}</Typography>
             </LinkHandler>

--- a/src/components/SideBar/SideBarMenu.js
+++ b/src/components/SideBar/SideBarMenu.js
@@ -50,7 +50,7 @@ const SideBarMenu = ({articleList}) => {
         {articleList.map(({title, slug}) => (
           <li key={slug} className={classes.listItem}>
             <LinkHandler
-              url={slug}
+              url={`/${slug}`}
               className={classNames(classes.link, {
                 [classes.activeLink]: slug === article,
               })}

--- a/src/components/SideBar/test/SideBar.test.js
+++ b/src/components/SideBar/test/SideBar.test.js
@@ -29,7 +29,7 @@ it('should render the correct article names', () => {
   articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
     articleLink.forEach(node =>
-      expect(node.parentNode).toHaveAttribute('href', slug),
+      expect(node.parentNode).toHaveAttribute('href', `/${slug}`),
     )
     expect(articleLink).toHaveLength(2)
   })

--- a/src/components/SideBar/test/SideBar.test.js
+++ b/src/components/SideBar/test/SideBar.test.js
@@ -24,7 +24,7 @@ it('should render the correct article names', () => {
   articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
     articleLink.forEach(node =>
-      expect(node.parentNode).toHaveAttribute('href', `/${slug}`),
+      expect(node.parentNode).toHaveAttribute('href', slug),
     )
     expect(articleLink).toHaveLength(2)
   })

--- a/src/stubs/articleData.js
+++ b/src/stubs/articleData.js
@@ -2,7 +2,7 @@ export default {
   contentfulArticle: {
     title: 'History',
     section: {
-      title: 'section title',
+      title: 'article Test',
       slug: '/section',
     },
     template: {

--- a/src/stubs/articleData.js
+++ b/src/stubs/articleData.js
@@ -1,10 +1,6 @@
 export default {
   contentfulArticle: {
     title: 'History',
-    section: {
-      title: 'article Test',
-      slug: '/section',
-    },
     template: {
       content: {
         json: {

--- a/src/stubs/articleData.js
+++ b/src/stubs/articleData.js
@@ -1,6 +1,10 @@
 export default {
   contentfulArticle: {
     title: 'History',
+    section: {
+      title: 'section title',
+      slug: 'section',
+    },
     template: {
       content: {
         json: {

--- a/src/templates/Article/Article.js
+++ b/src/templates/Article/Article.js
@@ -81,6 +81,10 @@ const Article = ({
 Article.propTypes = {
   data: shape({
     contentfulArticle: shape({
+      title: string.isRequired,
+      section: shape({
+        title: string.isRequired,
+      }).isRequired,
       template: shape({
         content: shape({
           json: object.isRequired,

--- a/src/templates/Article/Article.js
+++ b/src/templates/Article/Article.js
@@ -32,11 +32,10 @@ const useStyles = makeStyles(theme => ({
 }))
 
 const Article = ({
-  pageContext: {articleList},
+  pageContext: {articleList, parentSection},
   data: {
     contentfulArticle: {
       title,
-      section,
       template: {content},
     },
   },
@@ -44,7 +43,7 @@ const Article = ({
   const classes = useStyles()
   return (
     <Layout title={title} className={classes.root}>
-      <ArticleBanner {...section} />
+      <ArticleBanner {...parentSection} />
       <Box
         maxWidth={1620}
         mx={{xs: '20px', lg: 'auto'}}
@@ -54,7 +53,7 @@ const Article = ({
         <Grid container spacing={5} width="100%">
           <Grid item md={3} implementation="css" smDown component={Hidden} />
           <Grid item md={9}>
-            <BreadcrumbsComponent breadcrumbs={[section]} />
+            <BreadcrumbsComponent breadcrumbs={[parentSection]} />
           </Grid>
           <Grid item xs={12} md={3} className={classes.articleSidebar}>
             <SideBar articleList={articleList} />
@@ -75,10 +74,6 @@ const Article = ({
 Article.propTypes = {
   data: shape({
     contentfulArticle: shape({
-      title: string.isRequired,
-      section: shape({
-        title: string.isRequired,
-      }).isRequired,
       template: shape({
         content: shape({
           json: object.isRequired,
@@ -102,10 +97,6 @@ export const query = graphql`
   query ArticleQuery($slug: String!) {
     contentfulArticle(slug: {eq: $slug}) {
       title
-      section {
-        title
-        slug
-      }
       template {
         content {
           json

--- a/src/templates/Article/Article.js
+++ b/src/templates/Article/Article.js
@@ -32,10 +32,11 @@ const useStyles = makeStyles(theme => ({
 }))
 
 const Article = ({
-  pageContext: {articleList, parentSection, slug},
+  pageContext: {slug, sectionSlug, articleList},
   data: {
     contentfulArticle: {
       title,
+      section,
       template: {content},
     },
   },
@@ -46,10 +47,10 @@ const Article = ({
     <Layout
       title={title}
       className={classes.root}
-      section={parentSection.slug}
+      section={sectionSlug}
       article={slug}
     >
-      <ArticleBanner {...parentSection} />
+      <ArticleBanner {...section} />
       <Box
         maxWidth={1620}
         mx={{xs: '20px', lg: 'auto'}}
@@ -59,7 +60,7 @@ const Article = ({
         <Grid container spacing={5} width="100%">
           <Grid item md={3} implementation="css" smDown component={Hidden} />
           <Grid item md={9}>
-            <BreadcrumbsComponent breadcrumbs={[parentSection]} />
+            <BreadcrumbsComponent breadcrumbs={[section]} />
           </Grid>
           <Grid item xs={12} md={3} className={classes.articleSidebar}>
             <SideBar articleList={articleList} />
@@ -105,6 +106,10 @@ export const query = graphql`
   query ArticleQuery($slug: String!) {
     contentfulArticle(slug: {eq: $slug}) {
       title
+      section {
+        title
+        slug
+      }
       template {
         content {
           json

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -16,7 +16,7 @@ const pageContext = {
     },
   ],
   parentSection: {
-    title: 'article Test',
+    title: 'History Section',
     slug: '/history/article-1',
   },
 }
@@ -30,8 +30,8 @@ test('should render title amd sidebar menu containing a list of articles', async
   )
   await waitForDomChange()
   expect(document.title).toEqual(data.contentfulArticle.title)
-  // Should appear in the title, mobile breadcrumbs and desktop breadcrumbs
-  expect(getAllByText(data.contentfulArticle.section.title).length).toBe(3)
+  // Should appear in the banner, mobile breadcrumbs and desktop breadcrumbs
+  expect(getAllByText(pageContext.parentSection.title).length).toBe(3)
   pageContext.articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
     articleLink.forEach(node =>

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -11,10 +11,14 @@ import data from '../../../stubs/articleData'
 const pageContext = {
   articleList: [
     {
-      title: 'article Test',
+      title: 'articleList Test',
       slug: '/history/article-1',
     },
   ],
+  parentSection: {
+    title: 'article Test',
+    slug: '/history/article-1',
+  },
 }
 
 test('should render title amd sidebar menu containing a list of articles', async () => {

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -31,7 +31,7 @@ test('should render title amd sidebar menu containing a list of articles', async
   pageContext.articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
     articleLink.forEach(node =>
-      expect(node.parentNode).toHaveAttribute('href', `/${slug}`),
+      expect(node.parentNode).toHaveAttribute('href', slug),
     )
     expect(articleLink).toHaveLength(2)
   })

--- a/src/templates/Article/test/Article.test.js
+++ b/src/templates/Article/test/Article.test.js
@@ -12,14 +12,11 @@ const pageContext = {
   articleList: [
     {
       title: 'articleList Test',
-      slug: '/history/article-1',
+      slug: 'history/article-1',
     },
   ],
-  parentSection: {
-    title: 'History Section',
-    slug: '/history/article-1',
-  },
   slug: 'article',
+  sectionSlug: 'section',
 }
 
 test('should render title amd sidebar menu containing a list of articles', async () => {
@@ -32,11 +29,11 @@ test('should render title amd sidebar menu containing a list of articles', async
   await waitForDomChange()
   expect(document.title).toEqual(data.contentfulArticle.title)
   // Should appear in the banner, mobile breadcrumbs and desktop breadcrumbs
-  expect(getAllByText(pageContext.parentSection.title).length).toBe(3)
+  expect(getAllByText(data.contentfulArticle.section.title).length).toBe(3)
   pageContext.articleList.forEach(({title, slug}) => {
     const articleLink = getAllByText(title)
     articleLink.forEach(node =>
-      expect(node.parentNode).toHaveAttribute('href', slug),
+      expect(node.parentNode).toHaveAttribute('href', `/${slug}`),
     )
     expect(articleLink).toHaveLength(2)
   })


### PR DESCRIPTION
## Description
Created a linkhandler component to identify wether a link is internal (and should use gatsby link) or an external link (which opens in a new tab) for use in rich text

## Changelog
Description about the modification

## Checks

- [ ] Responsive on mobile

- [ ] Implementation documented 

- [ ] 80% test coverage

- [ ] Ticket meets all Acceptance Criteria

- [ ] Matches/ aligns to content model

- [ ] Content model diagram updated


## Tested in 
- [ ] Chrome
- [ ] Safari

## Screenshots
