### PR TITLE
:lipstick: Adding padding to person's name

### DIFF
--- a/src/components/Person/Person.js
+++ b/src/components/Person/Person.js
@@ -28,6 +28,7 @@ const useStyles = makeStyles(theme => ({
   },
   title: {
     fontWeight: 'bold',
+    paddingBottom: '20px',
   },
 }))
 


### PR DESCRIPTION
Co-authored-by: Ajesh Jally <ajeshjally@gmail.com>


## Description
Added requested padding under person's name

## Changelog
Description about the modification

## Checks

- [x] Responsive on mobile

- [ ] Implementation documented 

- [x] 80% test coverage

- [x] Ticket meets all Acceptance Criteria

- [ ] Matches/ aligns to content model

- [ ] Content model diagram updated


## Tested in 
- [ ] Chrome
- [ ] Safari

## Screenshots
