### PR TITLE
:bug: Adding Mobile back breadcrumb on section to home

### DIFF
--- a/src/components/Breadcrumbs/MobileBreadcrumbs.js
+++ b/src/components/Breadcrumbs/MobileBreadcrumbs.js
@@ -5,18 +5,23 @@ import Box from '@material-ui/core/Box'
 import BreadcrumbLink from './BreadcrumbLink'
 
 const MobileBreadcrumbs = ({breadcrumbs, backText}) => {
-  const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1]
+  const lastBreadcrumb =
+    breadcrumbs.length === 0
+      ? {
+          slug: '',
+          title: 'Home',
+        }
+      : breadcrumbs[breadcrumbs.length - 1]
+
   return (
-    !!lastBreadcrumb && (
-      <Box>
-        <Typography variant="body1">
-          <span>{backText}</span>
-          <BreadcrumbLink url={`/${lastBreadcrumb.slug}`}>
-            {lastBreadcrumb.title}
-          </BreadcrumbLink>
-        </Typography>
-      </Box>
-    )
+    <Box>
+      <Typography variant="body1">
+        <span>{backText}</span>
+        <BreadcrumbLink url={`/${lastBreadcrumb.slug}`}>
+          {lastBreadcrumb.title}
+        </BreadcrumbLink>
+      </Typography>
+    </Box>
   )
 }
 

--- a/src/components/Breadcrumbs/test/MobileBreadcrumbs.test.js
+++ b/src/components/Breadcrumbs/test/MobileBreadcrumbs.test.js
@@ -20,9 +20,9 @@ test('Should list just the last breadcrumb on mobile', () => {
   expect(queryByText(breadcrumbs[1].title)).toBeInTheDocument()
 })
 
-test('Should return null if the breadcrumbs array is empty', () => {
-  const {container} = render(
+test('Should return home if the breadcrumbs array is empty', () => {
+  const {queryByText} = render(
     <MobileBreadcrumbs breadcrumbs={[]} {...copyText} />,
   )
-  expect(container).toBeEmpty()
+  expect(queryByText('Home')).toBeInTheDocument()
 })


### PR DESCRIPTION
Co-authored-by: kkennedyAND <kkennedy@and.digital>
Co-authored-by: Arjun Yadav <arjun.prakash.yadav@gmail.com>

## Description

The section page was found to have no breadcrumb in mobile view

## Checks

- [ ] Ticket meets all Acceptance Criteria

- [x] Responsive on Desktop, Mobile and Tablet

- [x] 90% test coverage

- [ ] Documentation updated

## Screenshots

<img width="501" alt="Screenshot 2020-04-08 at 11 46 29" src="https://user-images.githubusercontent.com/16687043/78775716-975d1c00-798e-11ea-9799-12deb2d59acf.png">
